### PR TITLE
readme: use status code of `type skerrick`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Or, if you're using Quelpa:
 (quelpa '(skerrick :repo "anonimitoraf/skerrick" :fetcher github))
 
 ;; Needs to be run on the very first install of skerrick. Or when you want to upgrade.
-(unless (equal (shell-command-to-string "type skerrick") "skerrick not found\n")
+(if (eq (shell-command "type skerrick") 1)
   (skerrick-install-or-upgrade-server-binary))
 
 ;; Should be run in a JS buffer; it is buffer specific.


### PR DESCRIPTION
Minor README fix, I copied this line blindly and noticed it triggered every time I launched Emacs. Seems like my peculiar Bash installation yielded a string that's pretty far from what the line expects:
```
/opt/homebrew/bin/bash: line 1: type: skerrick: not found
```
I also tested it on an Ubuntu server and the output is different enough from the other two:
```
-bash: type: skerrick: not found
```
So I guess opting to just use the error code is preferable?

Thanks a bunch for this package<3